### PR TITLE
Adds support for getText style translations

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -44,7 +44,8 @@ function configI18n(userSettings) {
       .use(LngDetector)
       .use(XHR)
       .init({
-        fallbackLng: 'en',
+        returnEmptyString: false,
+        fallbackLng: false,
         keySeparator: '|',
         backend: {
           loadPath: '/i18n/{{lng}}.json'


### PR DESCRIPTION
The fallback language is set to "false" to use the keys
as the translation.
Additionally because the en.pot file will not have any translations
as the keys are already english, we won't allow emptyString values
to be used as translations. Those translations will therefore fall
back to the "key".