### PR TITLE
fix: allow programRuleAction translations [DHIS2-12971]

### DIFF
--- a/src/pages/Translations/TranslationCard.js
+++ b/src/pages/Translations/TranslationCard.js
@@ -69,7 +69,7 @@ const TranslationCard = (props) => {
                     alignItems="center"
                 >
                     <Grid item xs={6}>
-                        <h3>{props.object.name}</h3>
+                        <h3>{props.object[props.cardTitleProperty]}</h3>
                     </Grid>
                     <Grid style={translationCardStyles.icon} item xs={6}>
                         {getState() === TRANSLATED_ID && (
@@ -145,6 +145,7 @@ const TranslationCard = (props) => {
 }
 
 TranslationCard.propTypes = {
+    cardTitleProperty: PropTypes.string.isRequired,
     clearFeedback: PropTypes.func.isRequired,
     hasUnsavedChanges: PropTypes.func.isRequired,
     localeId: PropTypes.string.isRequired,

--- a/src/pages/Translations/TranslationsList.js
+++ b/src/pages/Translations/TranslationsList.js
@@ -54,6 +54,7 @@ const TranslationsList = (props) =>
                     openCard={props.openCard(object.id)}
                     openCardOnClick={props.openCardOnClick(object.id)}
                     clearFeedback={props.clearFeedback}
+                    cardTitleProperty={props.cardTitleProperty}
                 />
             ))}
             {PaginationBuilder(
@@ -67,6 +68,7 @@ const TranslationsList = (props) =>
     )
 
 TranslationsList.propTypes = {
+    cardTitleProperty: PropTypes.string.isRequired,
     clearFeedback: PropTypes.func.isRequired,
     goToNextPage: PropTypes.func.isRequired,
     goToPreviousPage: PropTypes.func.isRequired,

--- a/src/pages/Translations/index.js
+++ b/src/pages/Translations/index.js
@@ -19,6 +19,10 @@ const DEFAULT_SNACKBAR_CONF = {
     onActionClick: null,
 }
 
+const OVERRIDE_TITLE_AND_SEARCH_PROPS = {
+    programRuleAction: 'content',
+}
+
 /* auxiliar methods */
 /* FIXME move to an external file, SchemaEntry class */
 const modelToSchemaEntry = (model) => ({
@@ -538,7 +542,7 @@ class TranslationsPage extends PureComponent {
             model
                 .list({
                     paging: false,
-                    fields: 'id,displayName,name,translations',
+                    fields: 'id,displayName,name,content,translations',
                 })
                 .then((objects) => {
                     const objectInstances = objects ? objects.toArray() : []
@@ -653,14 +657,17 @@ class TranslationsPage extends PureComponent {
                 .trim()
                 .toLowerCase()
             const newElements = []
-
             for (let i = 0; i < elements.length; i++) {
                 const element = elements[i]
                 if (
-                    element.name
-                        .trim()
-                        .toLowerCase()
-                        .includes(currentSearchTerm)
+                    element[
+                        OVERRIDE_TITLE_AND_SEARCH_PROPS[
+                            searchFilter.selectedObject?.id
+                        ] ?? 'name'
+                    ]
+                        ?.trim()
+                        ?.toLowerCase()
+                        ?.includes(currentSearchTerm)
                 ) {
                     const flatElement = flatElementForPropertiesAndLocale(
                         element,
@@ -835,6 +842,11 @@ class TranslationsPage extends PureComponent {
                     openCardOnClick={this.openCardOnClick}
                     hasUnsavedChanges={this.hasUnsavedChanges}
                     clearFeedback={this.clearFeedbackSnackbar}
+                    cardTitleProperty={
+                        OVERRIDE_TITLE_AND_SEARCH_PROPS[
+                            this.state?.searchFilter?.selectedObject?.id
+                        ] ?? 'name'
+                    }
                 />
                 <div id="feedback-snackbar">{feedbackElement}</div>
                 <ConfirmationDialog


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-12971

In general, we filter items for translation based on name (and also show that name in the card for each object available to translate). However, programRuleActions do not have names, and the only translatable property is `content`.

I have added in some logic that lets us override `name` as the default property for search/card title so that programRuleActions can appear in the app.

**Before**
Doesn't load, you get a snackbar warning of `Cannot read properties of undefined (reading 'trim')`

**After**
<img width="1173" alt="image" src="https://github.com/dhis2/translations-app/assets/18490902/d8caf389-696b-4bc3-9126-c47941f36e92">

