### PR TITLE
fix: add/handle missing property translations [DHIS2-11316]

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -37,6 +37,14 @@ export const i18nKeys = {
         actionButton: {
             label: 'Save',
         },
+        domainAxisLabel: 'Domain axis label',
+        rangeAxisLabel: 'Range axis label',
+        targetLineLabel: 'Target line label',
+        subtitle: 'Subtitle',
+        title: 'Title',
+        baseLineLabel: 'Base line label',
+        subjectTemplate: 'Subject template',
+        messageTemplate: 'Message template',
     },
     messages: {
         unsavedChanges:

--- a/src/pages/Translations/TranslationCard.js
+++ b/src/pages/Translations/TranslationCard.js
@@ -107,7 +107,7 @@ const TranslationCard = (props) => {
                                             label={i18n.t(
                                                 i18nKeys.translationForm[
                                                     property.name
-                                                ]
+                                                ] ?? property.name
                                             )}
                                             onChange={onChange(
                                                 property.translationKey


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-11316

This adds in some translation strings for translatable properties that were missing (and falls back to the untranslated/unmapped property name if there is no translation string).

**Before**
<img width="1286" alt="image" src="https://github.com/dhis2/translations-app/assets/18490902/2943eb38-f74d-43b0-b8de-d9f98414afbc">



**After**
<img width="1267" alt="image" src="https://github.com/dhis2/translations-app/assets/18490902/d1e9c2ca-294f-4cde-983f-9909f62b852f">
