### PR TITLE
fix: type of minDHIS2Version

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -8,7 +8,7 @@ const config = {
     entryPoints: {
         app: './src/App.jsx',
     },
-    minDHIS2Version: 2.41,
+    minDHIS2Version: '2.41',
 }
 
 module.exports = config


### PR DESCRIPTION
fixes a type issue in our config file which is preventing upload to app hub (https://github.com/dhis2/translations-app/actions/runs/21251582745/job/61154496443)